### PR TITLE
Fix compatibility with advtrains 2.5.0

### DIFF
--- a/advtrain_helpers.lua
+++ b/advtrain_helpers.lua
@@ -26,7 +26,7 @@ function delta_to_dir(delta_pos)
 end
 
 local function node_is_advtrains_rail(node)
-	return advtrains.is_track_and_drives_on(node.name)
+	return advtrains.is_track(node.name)
 end
 
 local function is_advtrains_rail_at_pos_or_below(pos)
@@ -187,9 +187,9 @@ local function direction_step_to_rail_params_sequence(dir_step)
 	end
 end
 
-local function try_bend_rail_start(start_pos, direction_delta)
+local function try_bend_rail_start(start_pos, direction_delta, player)
 	if advtrains.trackplacer then
-		advtrains.trackplacer.bend_rail(vector.add(start_pos, direction_delta), (8 + advtrain_helpers.direction_delta_to_advtrains_conn(direction_delta)) % 16)
+        advtrains.trackplacer.place_track(start_pos, "advtrains:dtrack", player:get_player_name(), player:get_look_horizontal())
 	end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -161,10 +161,10 @@ local function can_overwrite_track_at(player, pos, newnode, no_overwrite)
 	if oldname == newname and oldparam2 == newparam2 then
 		return false
 	end
-	if not advtrains.is_track_and_drives_on(oldname) then
+	if not advtrains.is_track(oldname) then
 		return newnode
 	end
-	if not advtrains.is_track_and_drives_on(newname) then
+	if not advtrains.is_track(newname) then
 		return false, S("@1 is not a track", quote_string(newname))
 	end
 	if next(oldndef.advtrains or {}) ~= nil then
@@ -246,7 +246,8 @@ function build_rail(player, start_pos, end_pos)
 		current_pos = vector.add(current_pos, step_delta)
 	end
 	if build_count > 0 then
-		advtrain_helpers.try_bend_rail_start(start_pos, direction_delta)
+        core.log(dump(player))
+		advtrain_helpers.try_bend_rail_start(start_pos, direction_delta, player)
 	end
 	minetest.chat_send_player(player:get_player_name(), S("Successfully built @1 piece(s) of tracks (expected @2 total)", build_successful_count, build_count))
 end


### PR DESCRIPTION
* Replace removed is_track_and_drives on with the simpler is_track
* Use the place_track API to bend (the bend function has been made local in advtrains)

This commit gets the mod working as-is with no modifications needed. However, I really think that 2.5.0 was a backwards step for mod compatibility (you would think according to semantic versioning it should be 3.0...), and I will tell orwell on the mailing list that backwards compatibility has been broken.